### PR TITLE
CODE_BLOCK dynamic name replacement

### DIFF
--- a/ASSEMBLY.md
+++ b/ASSEMBLY.md
@@ -53,7 +53,8 @@ for cross-version support.
   * Parameters may start with ':' to capture locals from outside the macro definition
   * WARNING:  N E V E R  call a macro in itself (directly or indirectly). As you might expect, that cannot possibly work, and will most likely crash the compiler
   * Data Types:
-    * CODE_BLOCK\[\<count>] (a code block in {}, where \<count> is the amount of dynamic variables, defaults to 0)
+    * CODE_BLOCK\[\<count>] (a code block in {}, where \<count> is the amount of dynamic variables, defaults to 0); 
+      when count != 0, it is expected to prefix the {} with \[\<target name> {',' \<target name>}] to declare where the values go (local variable only)
     * VARIABLE_ARG\[...] (a dynamic count (including 0) of the specific type; if no type should be specified, omit the \[])
     * VARIABLE (a variable reference, similar to C#'s 'out' keyword; can be used as a store target than; requires special inputs to work (currently only local, global or cell variables are allowed, in the future more might work))
   * Macro names can be overloaded

--- a/ASSEMBLY.md
+++ b/ASSEMBLY.md
@@ -61,7 +61,8 @@ for cross-version support.
   * Comes with an extra instruction, which should only be used in macros:
 * MACRO_PASTE \<macro param name> \['\[' \<access> {',' \<access>} ']'] \['->' \<target>]: pastes the code for a macro-parameter, 
   and optionally pushes the result into the target; Can be used to define special exchangeable sections in code (it is intended to be used with code blocks as parameters)
-  \<access> can be used to expose parameter names for dynamic replacement
+  \<access> can be used to expose parameter names for dynamic replacement, optionally prefixed with '!' to make the value static inlined (single eval)
+  WARNING: will raise an exception when trying to use a STORE on a complex \<expression> as \<access>, as that is generally not supported
 * MACRO_IMPORT \<module name with '.'> \['->' \['.'\] \<namespace with '.'>]: imports the global scope of another module into this scope. If '->' is used, it defines where to put the scope. If it starts with '.', it is relative to the current position, otherwise global.
   * WARNING: the other module must be imported first (TODO: import it manually here!)
 

--- a/ASSEMBLY.md
+++ b/ASSEMBLY.md
@@ -53,12 +53,14 @@ for cross-version support.
   * Parameters may start with ':' to capture locals from outside the macro definition
   * WARNING:  N E V E R  call a macro in itself (directly or indirectly). As you might expect, that cannot possibly work, and will most likely crash the compiler
   * Data Types:
-    * CODE_BLOCK (a code block in {})
+    * CODE_BLOCK\[\<count>] (a code block in {}, where \<count> is the amount of dynamic variables, defaults to 0)
     * VARIABLE_ARG\[...] (a dynamic count (including 0) of the specific type; if no type should be specified, omit the \[])
     * VARIABLE (a variable reference, similar to C#'s 'out' keyword; can be used as a store target than; requires special inputs to work (currently only local, global or cell variables are allowed, in the future more might work))
   * Macro names can be overloaded
   * Comes with an extra instruction, which should only be used in macros:
-* MACRO_PASTE \<macro param name> \['->' \<target>]: pastes the code for a macro-parameter, and optionally pushes the result into the target; Can be used to define special exchangeable sections in code (it is intended to be used with code blocks as parameters)
+* MACRO_PASTE \<macro param name> \['\[' \<access> {',' \<access>} ']'] \['->' \<target>]: pastes the code for a macro-parameter, 
+  and optionally pushes the result into the target; Can be used to define special exchangeable sections in code (it is intended to be used with code blocks as parameters)
+  \<access> can be used to expose parameter names for dynamic replacement
 * MACRO_IMPORT \<module name with '.'> \['->' \['.'\] \<namespace with '.'>]: imports the global scope of another module into this scope. If '->' is used, it defines where to put the scope. If it starts with '.', it is relative to the current position, otherwise global.
   * WARNING: the other module must be imported first (TODO: import it manually here!)
 
@@ -95,12 +97,12 @@ Expressions can be added as certain parameters to instructions to use instead of
   - @!\<global name>: static global variable
   - $\<local name>: local variable
   - §\<name>: access a variable from an outer scope
-  - &\<name>: access to a macro parameter
+  - &\<name>: access to a macro parameter (can be also used in most places were <name> should be used)
   - ~\<name>: static access to a builtin or a module
   - %\[\<n>]: top of stack, or the n-th item from TOS
   - \<access>\[\<index or expression>]: value by \[] operator
   - \<access>(\<... args>): call to the attribute; not allowed in CALL opcode source and STORE opcode source
-  - '\' for discarding the result of an expression (only when STORING)
+  - '\\' for discarding the result of an expression (only when STORING)
 - OP instruction, where everything except the 'OP' name is in a single bracket, e.g. "OP ($a + $b)"
 - A string literal with " as quotes, and \\" for escaping
 - A signed integer or floating-point number
@@ -149,10 +151,6 @@ Expressions can be added as certain parameters to instructions to use instead of
 - ATTR_TYPEDEF \<attr name> \<type definition> in class bodies
 - VAR_TYPEDEF \<variable name> \<type definition> everywhere to hint types
 - ..._TYPEDEF_STRICT for enforcing types
-- MACRO_PASTE \<parameter> \[ '(' \<arg> {',' \<arg>} ')' ]
-  - CODE_BLOCK Parameter Syntax: \['\[' \<arg name> {',' \<arg name>} ']' ] '{' \<code> '}'
-  - Allows macro CODE_BLOCK parameters to accept variables names dynamically
-  - Rewritten in MACRO_PASTE to use the correct variable
 - MACRO_PASTE / CODE_BLOCK: allow the macro to forbid access to internal locals
 
 - make the system more abstract preparing for python 3.11 (CACHE entries, redesigned CALL pattern, ...)

--- a/bytecodemanipulation/assembler/AbstractBase.py
+++ b/bytecodemanipulation/assembler/AbstractBase.py
@@ -50,6 +50,8 @@ class ParsingScope:
         self.macro_parameter_namespace: typing.Dict[str] = {}
         self.filled_locals = set()
 
+        self.current_macro_assembly = None
+
     def scope_name_generator(self, suffix="") -> str:
         name = f"%INTERNAL:{self._name_counter}"
         self._name_counter += 1

--- a/bytecodemanipulation/data/shared/expressions/LocalAccessExpression.py
+++ b/bytecodemanipulation/data/shared/expressions/LocalAccessExpression.py
@@ -31,7 +31,7 @@ class LocalAccessExpression(AbstractAccessExpression):
 
         if value not in scope.filled_locals:
             # todo: why is it warning for some stream tests?
-            warnings.warn(SyntaxWarning(f"Expected local variable '{value}' to be set ahead of time, but might be not set (cannot infer for custom jumps)"), stacklevel=1)
+            warnings.warn(SyntaxWarning(f"Expected local variable '{value}' to be set ahead of time, but might be not set (cannot infer for custom jumps)"), stacklevel=2)
 
         return [
             Instruction.create_with_token(

--- a/bytecodemanipulation/data/shared/instructions/CallAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/CallAssembly.py
@@ -279,18 +279,6 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
 
                     to_be_stored_at = []
 
-                    parser.try_consume(SpecialToken("$"))
-                    base = parser.try_parse_identifier_like()
-
-                    if base is None:
-                        raise throw_positioned_error(
-                            scope,
-                            [inner_opening_bracket, parser[0]],
-                            "Expected <expression> after '['",
-                        )
-
-                    to_be_stored_at.append(base)
-
                     while not parser.try_inspect() == SpecialToken("]"):
                         parser.try_consume(SpecialToken("$"))
                         base = parser.try_parse_identifier_like()

--- a/bytecodemanipulation/data/shared/instructions/CallAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/CallAssembly.py
@@ -274,7 +274,9 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
                     )
 
             elif not has_seen_keyword_arg:
-                if is_macro and (inner_opening_bracket := parser[0] == SpecialToken("<")):
+                if is_macro and ((inner_opening_bracket := parser[0]) == SpecialToken("[")):
+                    parser.consume(SpecialToken("["))
+
                     to_be_stored_at = []
 
                     parser.try_consume(SpecialToken("$"))
@@ -284,12 +286,12 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
                         raise throw_positioned_error(
                             scope,
                             [inner_opening_bracket, parser[0]],
-                            "Expected <expression> after '<'",
+                            "Expected <expression> after '['",
                         )
 
                     to_be_stored_at.append(base)
 
-                    while not parser.try_inspect() == SpecialToken(">"):
+                    while not parser.try_inspect() == SpecialToken("]"):
                         parser.try_consume(SpecialToken("$"))
                         base = parser.try_parse_identifier_like()
 
@@ -305,11 +307,11 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
                         if not parser.try_consume(SpecialToken(",")):
                             break
 
-                    if not parser.try_consume(SpecialToken(">")):
+                    if not parser.try_consume(SpecialToken("]")):
                         raise throw_positioned_error(
                             scope,
                             [inner_opening_bracket, parser[0]],
-                            "Expected '>' closing '<'",
+                            "Expected ']' closing '['",
                         )
 
                     expr = parser.parse_body(scope=scope)

--- a/bytecodemanipulation/data/shared/instructions/CallAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/CallAssembly.py
@@ -277,7 +277,8 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
                 if is_macro and (inner_opening_bracket := parser[0] == SpecialToken("<")):
                     to_be_stored_at = []
 
-                    base = parser.try_consume_access_to_value()
+                    parser.try_consume(SpecialToken("$"))
+                    base = parser.try_parse_identifier_like()
 
                     if base is None:
                         raise throw_positioned_error(
@@ -289,7 +290,8 @@ class AbstractCallAssembly(AbstractAssemblyInstruction, AbstractAccessExpression
                     to_be_stored_at.append(base)
 
                     while not parser.try_inspect() == SpecialToken(">"):
-                        base = parser.try_consume_access_to_value()
+                        parser.try_consume(SpecialToken("$"))
+                        base = parser.try_parse_identifier_like()
 
                         if base is None:
                             raise throw_positioned_error(

--- a/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
@@ -453,6 +453,7 @@ class MacroAssembly(AbstractAssemblyInstruction):
         scope = scope.copy()
         scope.scope_path = self.scope_path
         scope.module_file = self.module_path
+        scope.current_macro_assembly = self
 
         bytecode = []
 

--- a/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
@@ -457,6 +457,15 @@ class MacroAssembly(AbstractAssemblyInstruction):
         bytecode = []
 
         for arg_decl, arg_code in zip(self.args, args):
+            if isinstance(arg_decl.data_type_annotation, MacroAssembly.CodeBlockDataType):
+                if isinstance(arg_code, CompoundExpression) and hasattr(arg_code, "to_be_stored_at"):
+                    if len(arg_code.to_be_stored_at) != arg_decl.data_type_annotation.count:
+                        raise throw_positioned_error(
+                            scope,
+                            arg_decl.name,
+                            f"Expected {arg_decl.data_type_annotation.count} dynamic name entries, got {len(arg_code.to_be_stored_at)}"
+                        )
+
             if arg_decl.is_static:
                 scope.macro_parameter_namespace[arg_decl.name.text] = arg_decl.name.text
             else:

--- a/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/MacroAssembly.py
@@ -315,6 +315,13 @@ class MacroAssembly(AbstractAssemblyInstruction):
                             "expected <integer> after '[' to declare count",
                         )
 
+                    if not parser.try_consume(SpecialToken("]")):
+                        raise throw_positioned_error(
+                            scope,
+                            [opening_bracket, parser[0]],
+                            "expected ']' closing '[' in CODE_BLOCK",
+                        )
+
                 inst = cls.CodeBlockDataType(count=count)
                 return inst
 
@@ -374,7 +381,7 @@ class MacroAssembly(AbstractAssemblyInstruction):
                     parser.rollback()
 
                 if not parser.try_consume(SpecialToken(",")):
-                    parser.consume(SpecialToken(")"))
+                    parser.consume(SpecialToken(")"), err_arg=scope)
                     break
 
         if parser.try_consume(SpecialToken("-")):

--- a/bytecodemanipulation/data/shared/instructions/MacroPasteAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/MacroPasteAssembly.py
@@ -4,6 +4,7 @@ from bytecodemanipulation.assembler.AbstractBase import AbstractAccessExpression
 from bytecodemanipulation.assembler.AbstractBase import ParsingScope
 from bytecodemanipulation.assembler.Lexer import SpecialToken
 from bytecodemanipulation.assembler.Parser import Parser
+from bytecodemanipulation.assembler.syntax_errors import throw_positioned_error
 from bytecodemanipulation.assembler.util.tokenizer import IdentifierToken
 from bytecodemanipulation.data.shared.instructions.AbstractInstruction import (
     AbstractAssemblyInstruction,
@@ -28,6 +29,41 @@ class MacroPasteAssembly(AbstractAssemblyInstruction):
 
         name = parser.consume(IdentifierToken)
 
+        dynamic_names = []
+        if opening_bracket := parser.try_consume(SpecialToken("[")):
+            base = parser.try_consume_access_to_value()
+
+            if base is None:
+                raise throw_positioned_error(
+                    scope,
+                    [opening_bracket, parser[0]],
+                    "Expected <expression> after '[' for dynamic name access",
+                )
+
+            dynamic_names.append(base)
+
+            while parser.try_inspect() != SpecialToken("]"):
+                base = parser.try_consume_access_to_value()
+
+                if base is None:
+                    raise throw_positioned_error(
+                        scope,
+                        [opening_bracket, parser[0]],
+                        "Expected <expression> after ',' for dynamic name access",
+                    )
+
+                dynamic_names.append(base)
+
+                if not parser.try_consume(SpecialToken(",")):
+                    break
+
+            if not parser.try_consume(SpecialToken("]")):
+                raise throw_positioned_error(
+                    scope,
+                    [opening_bracket, parser[0]],
+                    "expected ']' to close '[' closing dynamic names",
+                )
+
         if parser.try_consume_multi([SpecialToken("-"), SpecialToken(">")]):
             target = parser.try_consume_access_to_value(
                 allow_primitives=False, scope=scope
@@ -35,24 +71,26 @@ class MacroPasteAssembly(AbstractAssemblyInstruction):
         else:
             target = None
 
-        return cls(name, target)
+        return cls(name, target, dynamic_names=dynamic_names)
 
-    def __init__(self, name: IdentifierToken, target: AbstractAccessExpression = None):
+    def __init__(self, name: IdentifierToken, target: AbstractAccessExpression = None, dynamic_names: typing.List[AbstractAccessExpression] = None):
         self.name = name
         self.target = target
+        self.dynamic_names = dynamic_names or []
 
     def __repr__(self):
-        return f"MACRO_PASTE({self.name.text}{'' if self.target is None else '-> '+repr(self.target)})"
+        return f"MACRO_PASTE({self.name.text}{repr(self.dynamic_names)[1:-1]}{'' if self.target is None else '-> '+repr(self.target)})"
 
     def __eq__(self, other):
         return (
             type(self) == type(other)
             and self.name == other.name
             and self.target == other.target
+            and self.dynamic_names == other.dynamic_names
         )
 
     def copy(self) -> "MacroPasteAssembly":
-        return type(self)(self.name, self.target.copy() if self.target else None)
+        return type(self)(self.name, self.target.copy() if self.target else None, [e.copy() for e in self.dynamic_names])
 
     def emit_bytecodes(
         self, function: MutableFunction, scope: ParsingScope

--- a/bytecodemanipulation/data/shared/instructions/MacroPasteAssembly.py
+++ b/bytecodemanipulation/data/shared/instructions/MacroPasteAssembly.py
@@ -14,7 +14,7 @@ from bytecodemanipulation.opcodes.Opcodes import Opcodes
 
 
 class MacroPasteAssembly(AbstractAssemblyInstruction):
-    # MACRO_PASTE <macro param name> ['->' <target>]
+    # MACRO_PASTE <macro param name> ['[' <access> {',' <access>} ']'] ['->' <target>]
     NAME = "MACRO_PASTE"
 
     @classmethod

--- a/bytecodemanipulation/standard_library.pyasm
+++ b/bytecodemanipulation/standard_library.pyasm
@@ -84,12 +84,11 @@ NAMESPACE std
             CALL &var.extend(&value) -> \
         }
 
-        MACRO ASSEMBLY filter(var VARIABLE, predicate_source VARIABLE, predicate CODE_BLOCK)
+        MACRO ASSEMBLY filter(var VARIABLE, predicate CODE_BLOCK[1])
         {
             DEF filtered(item)
             {
-                LOAD $item -> &predicate_source
-                MACRO_PASTE predicate
+                MACRO_PASTE predicate [$item]
                 RETURN %
             }
 
@@ -98,13 +97,12 @@ NAMESPACE std
             CALL &var.extend(~filter($filtered, $tmp)) -> \
         }
 
-        MACRO ASSEMBLY map(var VARIABLE, predicate_source VARIABLE, predicate CODE_BLOCK)
+        MACRO ASSEMBLY map(var VARIABLE, predicate CODE_BLOCK[1])
         {
             DEF mapping(item)
             {
-                LOAD $item -> &predicate_source
-                MACRO_PASTE predicate
-                RETURN %
+                MACRO_PASTE predicate [$item]
+                RETURN $item
             }
 
             LOAD &var.copy() -> $tmp
@@ -112,7 +110,7 @@ NAMESPACE std
             CALL &var.extend(~map($mapping, $tmp)) -> \
         }
 
-        MACRO ASSEMBLY reduce(var VARIABLE, lhs VARIABLE, rhs VARIABLE, reducer CODE_BLOCK)
+        MACRO ASSEMBLY reduce(var VARIABLE, reducer CODE_BLOCK[2])
         {
             IF OP (~len(&var) == 0)
             {
@@ -126,10 +124,7 @@ NAMESPACE std
 
             WHILE OP ($index < $max_size)
             {
-                LOAD $tmp -> &lhs
-                LOAD &var[$index] -> &rhs
-                MACRO_PASTE &reducer
-                STORE $tmp
+                MACRO_PASTE &reducer [$tmp, &var[$index]] -> $tmp
                 OP $index + 1 -> $index
             }
 

--- a/tests/test_Assembly.py
+++ b/tests/test_Assembly.py
@@ -1521,12 +1521,32 @@ DEF xy(a=0)
 
 MACRO test_macro_func_call_keyword_expansion(keyword)
 {
-    RETURN $xy(&keyword=4)
+    RETURN $:xy(&keyword=4)
 }
 
-CALL MACRO test_macro_func_call_keyword_expansion("key")
+CALL MACRO test_macro_func_call_keyword_expansion("a")
 """)
             return 0
+
+        self.assertEqual(target(), 4)
+
+    def test_macro_paste_parameterized_code_block_1(self):
+        @apply_operations
+        def target():
+            assembly("""    
+
+MACRO test_macro_paste_parameterized_code_block_1(code CODE_BLOCK[1])
+{
+    LOAD 10 -> $var
+    MACRO_PASTE &code [$var]
+}
+
+CALL MACRO test_macro_paste_parameterized_code_block_1([$local] { RETURN $local })
+        """)
+            return 0
+
+        self.assertEqual(target(), 10)
+
 
 class TestClassAssembly(TestCase):
     def test_class_assembly(self):

--- a/tests/test_Assembly.py
+++ b/tests/test_Assembly.py
@@ -1258,15 +1258,15 @@ class TestMacro(TestCase):
         def target():
             assembly(
                 """
-        MACRO test_macro_paste (param) {
-            MACRO_PASTE param
-        }
+MACRO test_macro_paste (param) {
+    MACRO_PASTE param
+}
 
-        LOAD 0 -> $test
-        CALL MACRO test_macro_paste({
-            LOAD 10 -> $test
-        })
-        RETURN $test
+LOAD 0 -> $test
+CALL MACRO test_macro_paste({
+    LOAD 10 -> $test
+})
+RETURN $test
         """
             )
             return -1

--- a/tests/test_Assembly.py
+++ b/tests/test_Assembly.py
@@ -1547,6 +1547,44 @@ CALL MACRO test_macro_paste_parameterized_code_block_1([$local] { RETURN $local 
 
         self.assertEqual(target(), 10)
 
+    def test_macro_paste_parameterized_code_block_non_static(self):
+        @apply_operations
+        def target():
+            assembly("""    
+
+MACRO test_macro_paste_parameterized_code_block_non_static(code CODE_BLOCK[1])
+{
+    LOAD 10 -> $var
+    MACRO_PASTE &code [$var]
+}
+
+CALL MACRO test_macro_paste_parameterized_code_block_non_static([$local] { LOAD 0 -> $|var\nRETURN $local })
+        """)
+            return -1
+
+        dis.dis(target)
+
+        self.assertEqual(target(), 0)
+
+    def test_macro_paste_parameterized_code_block_static(self):
+        @apply_operations
+        def target():
+            assembly("""    
+
+MACRO test_macro_paste_parameterized_code_block_static(code CODE_BLOCK[1])
+{
+    LOAD 10 -> $var
+    MACRO_PASTE &code [!$var]
+}
+
+CALL MACRO test_macro_paste_parameterized_code_block_static([$local] { LOAD 0 -> $|var\nRETURN $local })
+        """)
+            return 0
+
+        dis.dis(target)
+
+        self.assertEqual(target(), 10)
+
 
 class TestClassAssembly(TestCase):
     def test_class_assembly(self):

--- a/tests/test_StandardLibrary.py
+++ b/tests/test_StandardLibrary.py
@@ -125,7 +125,7 @@ std:stream:to_list($stream, $output)
                 """
 std:stream:initialize($stream)
 std:stream:extend($stream, $data)
-std:stream:reduce($stream, $lhs, $rhs, {
+std:stream:reduce($stream, [$lhs, $rhs] {
     OP $lhs + $rhs
 })
 STORE $output
@@ -151,7 +151,7 @@ STORE $output
 std:stream:initialize($stream)
 std:stream:extend($stream, $data)
 std:print($stream)
-std:stream:filter($stream, $var, {
+std:stream:filter($stream, [$var] {
     OP $var < 2 -> %
 })
 std:print($stream)
@@ -163,6 +163,7 @@ std:stream:to_list($stream, $output)
         self.assertEqual(target(), [0, 1])
 
     def test_stream_simple_map(self):
+        @apply_operations
         def target():
             data = (0, 1, 2)
             stream = None
@@ -171,7 +172,7 @@ std:stream:to_list($stream, $output)
                 """
 std:stream:initialize($stream)
 std:stream:extend($stream, $data)
-std:stream:map($stream, $var, {
+std:stream:map($stream, [$var] {
     OP $var + 1 -> $var
 })
 std:stream:to_list($stream, $output)
@@ -179,9 +180,7 @@ std:stream:to_list($stream, $output)
             )
             return output
 
-        mutable = MutableFunction(target)
-        apply_inline_assemblies(mutable)
-        mutable.reassign_to_function()
+        dis.dis(target)
 
         self.assertEqual(target(), [1, 2, 3])
 


### PR DESCRIPTION
Allows CODE_BLOCK parameters to declare hidden names, so when using MACRO_PASTE on the code block, you can selectively replace locals with certain code snippets (expressions)

Syntax:
- CODE_BLOCK\[\<count>]
- \[\<names>] { \<code> }
- MACRO_PASTE \<name> \[\<expression>]